### PR TITLE
Proof-of-concept: multi-arch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,29 @@
-FROM gliderlabs/logspout:master
+FROM dubodubonduponey/gliderlabs-logspout:v1 AS source
+
+FROM --platform=$BUILDPLATFORM golang:1.12-alpine3.10 AS build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --update bash git
+
+RUN go get github.com/Masterminds/glide
+
+COPY --from=source /src /go/src/github.com/gliderlabs/logspout
+
+WORKDIR /go/src/github.com/gliderlabs/logspout
+COPY modules.go .
+RUN go get
+RUN $GOPATH/bin/glide install
+
+RUN arch=${TARGETPLATFORM#*/} && arch=${arch%/*} \
+    && env GOOS=linux GOARCH=$arch go build -ldflags "-X main.Version=$(cat VERSION)-custom" -o /bin/logspout
+
+# Shipping image
+FROM alpine:3.10
+COPY --from=build /bin/logspout /bin/logspout
+
+ENTRYPOINT ["/bin/logspout"]
+VOLUME /mnt/routes
+EXPOSE 80

--- a/build-push.sh
+++ b/build-push.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+IMAGE_OWNER=dubodubonduponey
+IMAGE_NAME=logspout
+IMAGE_VERSION=v1
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+docker buildx create --name "$IMAGE_NAME"
+docker buildx use "$IMAGE_NAME"
+
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 -t "$IMAGE_OWNER/$IMAGE_NAME:$IMAGE_VERSION" --push .

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,1 @@
 #!/bin/sh
-set -e
-apk add --update go build-base git mercurial ca-certificates
-mkdir -p /go/src/github.com/gliderlabs
-cp -r /src /go/src/github.com/gliderlabs/logspout
-cd /go/src/github.com/gliderlabs/logspout
-export GOPATH=/go
-go get
-go build -ldflags "-X main.Version=$1" -o /bin/logspout
-apk del go git mercurial build-base
-rm -rf /go /var/cache/apk/* /root/.glide
-
-# backwards compatibility
-ln -fs /tmp/docker.sock /var/run/docker.sock


### PR DESCRIPTION
Just addressing #11 for my own needs right now.

- this is just a proof-of-concept
- this requires a modified version of the upstream (since the extension model of upstream relies on their binary image)
- for upstream, see changes at https://github.com/dubo-dubon-duponey/docker-gliderlabs-logspout/commit/fdf15b0fc2f983bab2698dcfa292a29194d84a1a

Bottom-line:
- this is very feasible
- the whole extension model of upstream should either be changed or this here should move away from the binary dependency and build upstream from source (which it is already doing btw… just from the source shipped in their container rather than from github…)

Demo multi-arch images are available at:
- https://hub.docker.com/r/dubodubonduponey/logspout/
- https://hub.docker.com/r/dubodubonduponey/gliderlabs-logspout

Signed-off-by: dubo-dubon-duponey <dubodubonduponey+github@pm.me>