### PR TITLE
Multi-arch alternative rewrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,41 @@
-FROM gliderlabs/logspout:master
+##########################
+# Building image
+##########################
+FROM --platform=$BUILDPLATFORM golang:1.12-alpine3.10 AS build
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# v3.2.6
+ENV LOGSPOUT_VERSION=591787f3d3202cbe029a9cff6c14e3a178e1f78c
+
+# Update and get bash and git
+RUN apk add --update bash git
+# Checkout logspout upstream
+WORKDIR /go/src/github.com/gliderlabs/logspout
+RUN git clone https://github.com/gliderlabs/logspout.git .
+RUN git checkout $LOGSPOUT_VERSION
+# Install glide and run it
+RUN go get github.com/Masterminds/glide
+RUN $GOPATH/bin/glide install
+
+# Add the logdna stuff
+COPY modules.go .
+COPY logdna ./vendor/github.com/logdna/logspout/logdna
+
+# Build it
+RUN arch=${TARGETPLATFORM#*/} && arch=${arch%/*} \
+    && env GOOS=linux GOARCH=$arch go build -ldflags "-X main.Version=$(cat VERSION)-custom" -o /bin/logspout
+
+##########################
+# Shipping image
+##########################
+FROM alpine:3.10
+
+# Backward compatible...
+COPY --from=build /bin/logspout /bin/logspout
+
+ENTRYPOINT ["/bin/logspout"]
+VOLUME /mnt/routes
+EXPOSE 80

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,11 @@
-#!/bin/sh
-set -e
-apk add --update go build-base git mercurial ca-certificates
-mkdir -p /go/src/github.com/gliderlabs
-cp -r /src /go/src/github.com/gliderlabs/logspout
-cd /go/src/github.com/gliderlabs/logspout
-export GOPATH=/go
-go get
-go build -ldflags "-X main.Version=$1" -o /bin/logspout
-apk del go git mercurial build-base
-rm -rf /go /var/cache/apk/* /root/.glide
+#!/usr/bin/env bash
 
-# backwards compatibility
-ln -fs /tmp/docker.sock /var/run/docker.sock
+IMAGE_OWNER="${IMAGE_OWNER:-dubodubonduponey}"
+IMAGE_NAME="${IMAGE_NAME:-logspout}"
+IMAGE_VERSION="${IMAGE_VERSION:-v1}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6}"
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+docker buildx create --name "$IMAGE_NAME"
+docker buildx use "$IMAGE_NAME"
+docker buildx build --platform "$PLATFORMS" -t "$IMAGE_OWNER/$IMAGE_NAME:$IMAGE_VERSION" --push .


### PR DESCRIPTION
This is an alternative to #12, taking the approach mentioned before (and that I now prefer for my own use):

- ditches upstream extension mechanism entirely
- use logdna source from the clone instead of pulling from github through glide
- get rid of the build.sh shenanigans and onbuild triggers

Gives:

- simplified, more grokable build pipeline
- faster to buid, more cacheable
- no binary dependency, only source
- easier to patch/fork upstream

To build it, just call `./build.sh` (it will fail pushing of course, read the script).