### PR TITLE
Build Docker images for multiple architectures (i.e. ARMv8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Check Tagged Push
           command: |
-            PKG_VERSION=$(grep BUILD_VERSION Dockerfile | cut -d' ' -f3)
+            PKG_VERSION=$(grep BUILD_VERSION Dockerfile | cut -d'=' -f2)
             if [[ "${CIRCLE_TAG}" != "v${PKG_VERSION}" ]]; then
               echo "There is mismatch:"
               echo "  TAG_VERSION: ${CIRCLE_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Check Tagged Push
           command: |
-            PKG_VERSION=$(grep VERSION Dockerfile | cut -d' ' -f3)
+            PKG_VERSION=$(grep BUILD_VERSION Dockerfile | cut -d' ' -f3)
             if [[ "${CIRCLE_TAG}" != "v${PKG_VERSION}" ]]; then
               echo "There is mismatch:"
               echo "  TAG_VERSION: ${CIRCLE_TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ RUN mkdir -p /go/src/github.com/gliderlabs && \
     cp -r /src /go/src/github.com/gliderlabs/logspout
 WORKDIR /go/src/github.com/gliderlabs/logspout
 ENV GOPATH=/go
+ENV CGO_ENABLED=0
 RUN go get
 RUN go build -ldflags "-X main.Version=$(cat VERSION)-logdna" -o /bin/logspout
 
 
-FROM alpine:3.12
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/logspout /bin/logspout
 ENV BUILD_VERSION=1.2.0
 VOLUME /mnt/routes
-RUN ln -fs /tmp/docker.sock /var/run/docker.sock
 ENTRYPOINT ["/bin/logspout"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM gliderlabs/logspout:latest AS builder
+RUN apk add --no-cache --update go build-base git mercurial ca-certificates
+RUN mkdir -p /go/src/github.com/gliderlabs && \
+    cp -r /src /go/src/github.com/gliderlabs/logspout
+WORKDIR /go/src/github.com/gliderlabs/logspout
+ENV GOPATH=/go
+RUN go get
+RUN go build -ldflags "-X main.Version=$(cat VERSION)-logdna" -o /bin/logspout
 
 
 FROM alpine:3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,9 @@
-FROM gliderlabs/logspout:latest
-ENV BUILD_VERSION 1.2.0
+FROM gliderlabs/logspout:latest AS builder
+
+
+FROM alpine:3.12
+COPY --from=builder /bin/logspout /bin/logspout
+ENV BUILD_VERSION=1.2.0
+VOLUME /mnt/routes
+RUN ln -fs /tmp/docker.sock /var/run/docker.sock
+ENTRYPOINT ["/bin/logspout"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ RUN apk add --no-cache --update go build-base git mercurial ca-certificates
 RUN mkdir -p /go/src/github.com/gliderlabs && \
     cp -r /src /go/src/github.com/gliderlabs/logspout
 WORKDIR /go/src/github.com/gliderlabs/logspout
+ARG ARCH=amd64
+ARG OS=linux
+ENV GOARCH=${ARCH}
+ENV GOOS=${OS}
 ENV GOPATH=/go
 ENV CGO_ENABLED=0
 RUN go get

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+REPO         = ${USERNAME}
+NAME         = logspout
+TAG          = ${CIRCLE_TAG}
+IMAGE        = $(REPO)/$(NAME)
+IMAGE_AMD64  = $(IMAGE):$(TAG)-amd64
+IMAGE_ARM64  = $(IMAGE):$(TAG)-arm64
+
+# Enable 'docker manifest' commands (still experimental in Docker v20.10.5)
+export DOCKER_CLI_EXPERIMENTAL = enabled
+
+build:
+	docker build --pull -t $(IMAGE_AMD64) \
+		--build-arg ARCH=amd64 \
+		--build-arg OS=linux \
+		-f Dockerfile .
+	docker build --pull -t $(IMAGE_ARM64) \
+		--build-arg ARCH=arm64 \
+		--build-arg OS=linux \
+		-f Dockerfile .
+	docker save -o image.tar $(IMAGE_AMD64) $(IMAGE_ARM64)
+
+publish:
+	docker load -i ./image.tar
+	docker push $(IMAGE_AMD64)
+	docker push $(IMAGE_ARM64)
+	docker manifest create $(IMAGE):$(TAG) $(IMAGE_AMD64) $(IMAGE_ARM64)
+	docker manifest annotate $(IMAGE):$(TAG) $(IMAGE_ARM64) --arch arm64 --os linux
+	docker manifest push --purge $(IMAGE):$(TAG)
+	docker manifest create $(IMAGE):latest $(IMAGE_AMD64) $(IMAGE_ARM64)
+	docker manifest annotate $(IMAGE):latest $(IMAGE_ARM64) --arch arm64 --os linux
+	docker manifest push --purge $(IMAGE):latest

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,9 @@
 #!/bin/sh
 set -e
-apk add --update go build-base git mercurial ca-certificates
+apk add --no-cache --update go build-base git mercurial ca-certificates
 mkdir -p /go/src/github.com/gliderlabs
 cp -r /src /go/src/github.com/gliderlabs/logspout
 cd /go/src/github.com/gliderlabs/logspout
 export GOPATH=/go
 go get
 go build -ldflags "-X main.Version=$1" -o /bin/logspout
-apk del go git mercurial build-base
-rm -rf /go /var/cache/apk/* /root/.glide
-
-# backwards compatibility
-ln -fs /tmp/docker.sock /var/run/docker.sock

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,3 @@
 #!/bin/sh
-set -e
-apk add --no-cache --update go build-base git mercurial ca-certificates
-mkdir -p /go/src/github.com/gliderlabs
-cp -r /src /go/src/github.com/gliderlabs/logspout
-cd /go/src/github.com/gliderlabs/logspout
-export GOPATH=/go
-go get
-go build -ldflags "-X main.Version=$1" -o /bin/logspout
+
+# File is empty to neutralize ONBUILD trigger in parent Dockerfile


### PR DESCRIPTION
This PR is a proof of concept for how to build Docker images for multiple architectures. It only builds for x86-64 and ARM64 here (as that is what I can verify), but it should be possible to support any OS / architecture combination that is supported by Docker and Go.

A few things to note regarding the commits:

1. The `Dockerfile` has been split to use stages. This allows us to cross-compile easily and also results in smaller images.
2. The Docker image is now `FROM scratch`, meaning it will be smaller and won't contain any debugging tools.
3. I've made no effort to update the CircleCI build machinery, but instead provide a `Makefile`. Should be easy enough to change to `make build` and `make publish` on the right places.
4. Please read commit comments if this is of interest, as things are further explained there.

Ideally, the base Logspout image should be multi-architecture already. But seeing that nothing seems to happen there I opted for this approach instead. Whenever they fix their issues, this solution should be revisited.