### PR TITLE
ci: Enable multi-arch builds via Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,17 @@ jobs:
       - checkout
       - run: go get -u golang.org/x/lint/golint
       - run: golint logdna/
-  imagest:
-    machine: true
+  imagetest:
+    machine:
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
-      - run: docker build -f Dockerfile .
+      - run: make build
   build:
     machine:
       docker_layer_caching: true
+      # This image contains a more recent version of docker to support `docker manifest`
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
       - run:
@@ -37,8 +40,7 @@ jobs:
               echo "  PKG_VERSION: v${PKG_VERSION}"
               exit 1
             fi
-      - run: docker build -f Dockerfile -t ${USERNAME}/${IMAGE}:${TAG} .
-      - run: docker save -o image.tar ${USERNAME}/${IMAGE}:${TAG}
+      - run: make build
       - persist_to_workspace:
           root: .
           paths:
@@ -71,13 +73,11 @@ jobs:
   publish:
     machine:
       docker_layer_caching: true
+      image: ubuntu-2004:202101-01
     steps:
       - attach_workspace:
           at: .
-      - run: docker load -i ./image.tar
-      - run: docker tag ${USERNAME}/${IMAGE}:${TAG} ${USERNAME}/${IMAGE}:${CIRCLE_TAG}
-      - run: docker login --username ${USERNAME} --password ${PASSWORD}
-      - run: docker push ${USERNAME}/${IMAGE}
+      - run: make publish
 workflows:
   update:
     jobs:
@@ -104,7 +104,7 @@ workflows:
     jobs:
       - test:
           filters: *test_build_filters
-      - imagest:
+      - imagetest:
           requires:
             - test
           filters: *test_build_filters

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
+TAG          = $(if $(CIRCLE_TAG),$(CIRCLE_TAG),PRTEST)
 REPO         = ${USERNAME}
 NAME         = logspout
-TAG          = ${CIRCLE_TAG}
 IMAGE        = $(REPO)/$(NAME)
 IMAGE_AMD64  = $(IMAGE):$(TAG)-amd64
 IMAGE_ARM64  = $(IMAGE):$(TAG)-arm64
@@ -20,6 +20,7 @@ build:
 	docker save -o image.tar $(IMAGE_AMD64) $(IMAGE_ARM64)
 
 publish:
+	docker login --username ${USERNAME} --password ${PASSWORD}
 	docker load -i ./image.tar
 	docker push $(IMAGE_AMD64)
 	docker push $(IMAGE_ARM64)


### PR DESCRIPTION
The building and tagging for multiple architectures is now done
within a Makefile in the project. Until such time where we
may switch to buildx or some other multi-arch approach, call
the build steps from the Makefile.

Semver: patch