### PR TITLE
chore: Bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents all notable changes in `LogDNA LogSpout Image`. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.0 - Released on April 20, 2021
+* Add a Makefile to do builds for multiple architectures (amd64, arm64)
+    * Correct CI workflow to build from a `Makefile`
+    * Use `docker manifest` to control tagging
+
 ## v1.2.0 - Released on February 20, 2020
 * Update License
 * Update Release Pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN go build -ldflags "-X main.Version=$(cat VERSION)-logdna" -o /bin/logspout
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/logspout /bin/logspout
-ENV BUILD_VERSION=1.2.0
+ENV BUILD_VERSION=1.3.0
 VOLUME /mnt/routes
 ENTRYPOINT ["/bin/logspout"]


### PR DESCRIPTION
This version contains builds for multiple architectures.