### PR TITLE
logdna/adapter: use sub second precision

### DIFF
--- a/logdna/adapter/adapter.go
+++ b/logdna/adapter/adapter.go
@@ -131,9 +131,11 @@ func (adapter *Adapter) Stream(logstream chan *router.Message) {
 			)
 		} else {
 			adapter.Queue <- Line{
-				Line:      string(messageStr),
-				File:      m.Container.Name,
-				Timestamp: time.Now().Unix(),
+				Line: string(messageStr),
+				File: m.Container.Name,
+				// We're on a very old Go version, so can't use stdlib function
+				// https://stackoverflow.com/a/24122933
+				Timestamp: m.Time.UnixNano() / 1e6,
 			}
 		}
 	}


### PR DESCRIPTION
This PR does two very minor things, for a decent UX improvement: 

1. Use the timestamp of the router message as the log line timestamp, instead of `time.Now()`
2. Use sub second precision for the timestamp